### PR TITLE
Added midi note map stub implementation to operator bases

### DIFF
--- a/src/Operator.php
+++ b/src/Operator.php
@@ -43,7 +43,7 @@ final class InputKind {
  *
  * Basic interface for linkable Operators. Operators combine Oscillators and control sources to sculpt sounds.
  */
-interface IOperator extends IStream {
+interface IOperator extends IStream, IMIDINoteMapAware {
 
     /**
      * Generic input attachment: Attaches another Operator as an input. Some Operators may support more than one

--- a/src/envelope/Generator.php
+++ b/src/envelope/Generator.php
@@ -162,6 +162,17 @@ class LinearInterpolated implements IGenerator {
 
     /**
      * @inheritdoc
+     *
+     * @see IMIDINumberAware
+     */
+    public function getNoteNumberMapUseCases() : array {
+        return array_keys(self::A_MAPS);
+    }
+
+    /**
+     * @inheritdoc
+     *
+     * @see IMIDINumberAware
      */
     public function setNoteNumberMap(IMIDINoteMap $oNoteMap, string $sUseCase = null) : IMIDINoteMapAware {
         if (isset(self::A_MAPS[$sUseCase])) {
@@ -173,6 +184,8 @@ class LinearInterpolated implements IGenerator {
 
     /**
      * @inheritdoc
+     *
+     * @see IMIDINumberAware
      */
     public function getNoteNumberMap(string $sUseCase = null) : IMIDINoteMap {
         if (null !== $sUseCase && isset($this->aNoteMaps[$sUseCase])) {
@@ -184,6 +197,8 @@ class LinearInterpolated implements IGenerator {
 
     /**
      * @inheritdoc
+     *
+     * @see IMIDINumberAware
      */
     public function setNoteNumber(int $iNote) : IMIDINoteMapAware {
         // If the note number has changed, use the key scale map to obtain the time scaling to use for that note
@@ -214,6 +229,8 @@ class LinearInterpolated implements IGenerator {
 
     /**
      * @inheritdoc
+     *
+     * @see IMIDINumberAware
      */
     public function setNoteName(string $sNote) : IMIDINoteMapAware {
         // Just use the first Note Map, if any, to convert the note name.

--- a/src/map/MIDINote.php
+++ b/src/map/MIDINote.php
@@ -46,6 +46,13 @@ interface IMIDINumber {
 interface IMIDINumberAware {
 
     /**
+     * Obtain a list of use cases that IMIDINumber maps can be set for.
+     *
+     * @return string[]
+     */
+    public function getNoteNumberMapUseCases() : array;
+
+    /**
      * Set a new Note Map. An implementor may use multiple Note Maps for multiple things, for exanple, the effect of
      * note number on envelope speeds, amplitudes, filter cutoff etc. The use cases are specific to the implementor.
      *

--- a/src/operator/Base.php
+++ b/src/operator/Base.php
@@ -5,6 +5,9 @@ namespace ABadCafe\Synth\Operator;
 use ABadCafe\Synth\Signal\Packet;
 use ABadCafe\Synth\Utility\IEnumeratedInstance;
 use ABadCafe\Synth\Utility\TEnumeratedInstance;
+use ABadCafe\Synth\Map\Note\IMIDINumber      as IMIDINoteMap;
+use ABadCafe\Synth\Map\Note\IMIDINumberAware as IMIDINoteMapAware;
+use AbadCafe\Synth\Map\Note\Invariant        as IMIDIInvariantNoteMap;
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -31,6 +34,61 @@ abstract class Base implements IOperator, IEnumeratedInstance {
      */
     public function emit() : Packet {
         return $this->emitPacketForIndex($this->iPacketIndex + 1);
+    }
+
+    /**
+     * @inheritdoc
+     *
+     * This is a stub and should be overridden by any implementation supporting a number map control
+     *
+     * @see IMIDINumberAware
+     */
+    public function getNoteNumberMapUseCases() : array {
+        return [];
+    }
+
+    /**
+     * @inheritdoc
+     *
+     * This is a stub and should be overridden by any implementation supporting a number map control
+     *
+     * @see IMIDINumberAware
+     */
+    public function setNoteNumberMap(IMIDINoteMap $oNoteMap, string $sUseCase = null) : IMIDINoteMapAware {
+        return $this;
+    }
+
+    /**
+     * @inheritdoc
+     *
+     * This is a stub and should be overridden by any implementation supporting a number map control
+     *
+     * @see IMIDINumberAware
+     */
+    public function getNoteNumberMap(string $sUseCase = null) : IMIDINoteMap {
+        return IMIDIInvariantNoteMap::get();
+    }
+
+    /**
+     * @inheritdoc
+     *
+     * This is a stub and should be overridden by any implementation supporting a number map control
+     *
+     * @see IMIDINumberAware
+     */
+    public function setNoteNumber(int $iNote) : IMIDINoteMapAware {
+        return $this;
+    }
+
+    /**
+     * @inheritdoc
+     *
+     * This is a stub and should be overridden by any implementation supporting a number map control
+     *
+     * @see IMIDINumberAware
+     */
+    public function setNoteName(string $sNote) : IMIDINoteMapAware {
+        return $this;
     }
 
     /**


### PR DESCRIPTION
- Added note map awareness interface to Operator interface
- Implemented "do nothing" stubs in base Operator, subclasses to define actual behaviours.
- Note map aware implementors now must return an array of all supported use case identifiers.