### PR TITLE
Note Map support for Filter Operator

### DIFF
--- a/src/envelope/Generator.php
+++ b/src/envelope/Generator.php
@@ -174,7 +174,7 @@ class LinearInterpolated implements IGenerator {
      *
      * @see IMIDINumberAware
      */
-    public function setNoteNumberMap(IMIDINoteMap $oNoteMap, string $sUseCase = null) : IMIDINoteMapAware {
+    public function setNoteNumberMap(IMIDINoteMap $oNoteMap, string $sUseCase) : IMIDINoteMapAware {
         if (isset(self::A_MAPS[$sUseCase])) {
             $this->aNoteMaps[$sUseCase] = $oNoteMap;
             $this->recalculate();
@@ -187,7 +187,7 @@ class LinearInterpolated implements IGenerator {
      *
      * @see IMIDINumberAware
      */
-    public function getNoteNumberMap(string $sUseCase = null) : IMIDINoteMap {
+    public function getNoteNumberMap(string $sUseCase) : IMIDINoteMap {
         if (null !== $sUseCase && isset($this->aNoteMaps[$sUseCase])) {
             return $this->aNoteMaps[$sUseCase];
         }

--- a/src/map/MIDINote.php
+++ b/src/map/MIDINote.php
@@ -56,24 +56,20 @@ interface IMIDINumberAware {
      * Set a new Note Map. An implementor may use multiple Note Maps for multiple things, for exanple, the effect of
      * note number on envelope speeds, amplitudes, filter cutoff etc. The use cases are specific to the implementor.
      *
-     * While the use case parameter is optional in this interface, it may be mandatory for some implementations.
-     *
      * @param  IMIDINumber $oNoteMap
      * @param  string      $sUseCase
      * @return self
      */
-    public function setNoteNumberMap(IMIDINumber $oNoteMap, string $sUseCase = null) : self;
+    public function setNoteNumberMap(IMIDINumber $oNoteMap, string $sUseCase) : self;
 
     /**
      * Get the current Note Map.
-     *
-     * While the use case parameter is optional in this interface, it may be mandatory for some implementations.
      *
      * @param string $sUseCase
      *
      * @return IMIDINumber
      */
-    public function getNoteNumberMap(string $sUseCase = null) : IMIDINumber;
+    public function getNoteNumberMap(string $sUseCase) : IMIDINumber;
 
     /**
      * Set the note number to use. The expectation is that the consuming class will use the Note Map to derive some

--- a/src/operator/Base.php
+++ b/src/operator/Base.php
@@ -54,7 +54,7 @@ abstract class Base implements IOperator, IEnumeratedInstance {
      *
      * @see IMIDINumberAware
      */
-    public function setNoteNumberMap(IMIDINoteMap $oNoteMap, string $sUseCase = null) : IMIDINoteMapAware {
+    public function setNoteNumberMap(IMIDINoteMap $oNoteMap, string $sUseCase) : IMIDINoteMapAware {
         return $this;
     }
 
@@ -65,7 +65,7 @@ abstract class Base implements IOperator, IEnumeratedInstance {
      *
      * @see IMIDINumberAware
      */
-    public function getNoteNumberMap(string $sUseCase = null) : IMIDINoteMap {
+    public function getNoteNumberMap(string $sUseCase) : IMIDINoteMap {
         return IMIDIInvariantNoteMap::get();
     }
 


### PR DESCRIPTION
- Made the use case parameter of the note map awareness interface mandatory.
- Implemented note map support on the Filter operator.
- Uses a forwarding strategy where whichever note maps the cutoff and resonance control inputs support are automatically enumerated and exposed by the filter operator.